### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc,vendor
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = ore,crate

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/WARNINGS.md
+++ b/WARNINGS.md
@@ -246,7 +246,7 @@ test-2:
 
 ### Mitigation
 
-* Use `.WAIT` as an optional pseudo-prerequisite syncronization marker
+* Use `.WAIT` as an optional pseudo-prerequisite synchronization marker
 * Avoid declaring `.WAIT` as a target.
 
 ## PHONY_NOP
@@ -286,14 +286,14 @@ clean:
 
 ### Mitigation
 
-* Use `.WAIT` as an optional pseudo-prerequisite syncronization marker
+* Use `.WAIT` as an optional pseudo-prerequisite synchronization marker
 * Avoid declaring `.WAIT` as a target.
 
 ## REDUNDANT_NOTPARALLEL_WAIT
 
 The `.WAIT` pseudo-prerequisite disables asynchronous processing between prerequisites of a specific rule.
 
-`.NOTPARALLEL:` disables asyncronous processing for all prerequisites in all rules.
+`.NOTPARALLEL:` disables asynchronous processing for all prerequisites in all rules.
 
 Using both of these special targets simultaneously is unnecessary.
 


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.